### PR TITLE
get the default interface

### DIFF
--- a/prlctl-ssh.sh
+++ b/prlctl-ssh.sh
@@ -7,10 +7,17 @@ getVmStatus() {
   return 0
 }
 
+# Get default interface of the vm
+# @param $1 vm-name or id
+getVmIface() {
+  prlctl exec $1 route | grep '^default' | grep -o '[^ ]*$'
+  return 0
+}
+
 # get ip address of vm
 # @param $1 vm-name or id
 getVmAddr() {
-  prlctl exec $1 ifconfig eth0 | grep "inet addr" | awk -F: '{print $2}' | awk '{print $1}'
+  prlctl exec $1 ifconfig `getVmIface $vm` | grep "inet addr" | awk -F: '{print $2}' | awk '{print $1}'
   return 0
 }
 


### PR DESCRIPTION
Solves the problem when the default interface is not named "eth0"